### PR TITLE
Enable release PRs to be based on a branch that isn't the base branch

### DIFF
--- a/__snapshots__/cli.js
+++ b/__snapshots__/cli.js
@@ -25,6 +25,9 @@ Options:
   --repo-url                    GitHub URL to generate release for    [required]
   --dry-run                     Prepare but do not take action
                                                       [boolean] [default: false]
+  --use-graphql                 Whether or not the GraphQL API should be used.
+                                If false, the REST API will be used instead.
+                                                       [boolean] [default: true]
   --include-v-in-tags           include "v" in tag versions
                                                        [boolean] [default: true]
   --monorepo-tags               include library name in tags and release
@@ -91,6 +94,9 @@ Options:
                         on                                              [string]
   --repo-url            GitHub URL to generate release for            [required]
   --dry-run             Prepare but do not take action[boolean] [default: false]
+  --use-graphql         Whether or not the GraphQL API should be used. If false,
+                        the REST API will be used instead.
+                                                       [boolean] [default: true]
   --label               comma-separated list of labels to add to from release PR
                                                [default: "autorelease: pending"]
   --skip-labeling       skip application of labels to pull requests
@@ -132,6 +138,8 @@ Options:
                                                                         [string]
   --repo-url        GitHub URL to generate release for                [required]
   --dry-run         Prepare but do not take action    [boolean] [default: false]
+  --use-graphql     Whether or not the GraphQL API should be used. If false, the
+                    REST API will be used instead.     [boolean] [default: true]
   --draft           mark release as a draft. no tag is created but tag_name and
                     target_commitish are associated with the release for future
                     tag creation upon "un-drafting" the release.
@@ -179,6 +187,9 @@ Options:
   --repo-url                        GitHub URL to generate release for[required]
   --dry-run                         Prepare but do not take action
                                                       [boolean] [default: false]
+  --use-graphql                     Whether or not the GraphQL API should be
+                                    used. If false, the REST API will be used
+                                    instead.           [boolean] [default: true]
   --release-as                      override the semantically determined release
                                     version                             [string]
   --bump-minor-pre-major            should we bump the semver minor prior to the

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prepare": "npm run compile",
     "lint": "gts check",
     "compile": "tsc -p .",
+    "cli": "npm run compile && node build/src/bin/release-please.js",
     "fix": "gts fix",
     "pretest": "npm run compile"
   },

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -441,7 +441,6 @@ const createReleasePullRequestCommand: yargs.CommandModule<
   async handler(argv) {
     const github = await buildGitHub(argv);
     const targetBranch = argv.targetBranch || github.repository.defaultBranch;
-    const changesBranch = argv.changesBranch || targetBranch;
     let manifest: Manifest;
     if (argv.releaseType) {
       manifest = await Manifest.fromConfig(

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -49,6 +49,7 @@ interface GitHubArgs {
   apiUrl?: string;
   graphqlUrl?: string;
   fork?: boolean;
+  useGraphql?: boolean;
 
   // deprecated in favor of targetBranch
   defaultBranch?: string;
@@ -182,6 +183,12 @@ function gitHubOptions(yargs: yargs.Argv): yargs.Argv {
       describe: 'Prepare but do not take action',
       type: 'boolean',
       default: false,
+    })
+    .option('use-graphql', {
+      describe:
+        'Whether or not the GraphQL API should be used. If false, the REST API will be used instead.',
+      type: 'boolean',
+      default: true,
     })
     .middleware(_argv => {
       const argv = _argv as GitHubArgs;
@@ -792,6 +799,7 @@ async function buildGitHub(argv: GitHubArgs): Promise<GitHub> {
     token: argv.token!,
     apiUrl: argv.apiUrl,
     graphqlUrl: argv.graphqlUrl,
+    useGraphql: argv.useGraphql,
   });
   return github;
 }

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -486,7 +486,7 @@ const createReleasePullRequestCommand: yargs.CommandModule<
       const pullRequests = await manifest.buildPullRequests();
       console.log(`Would open ${pullRequests.length} pull requests`);
       console.log('fork:', manifest.fork);
-      console.log('➡️➡️➡️➡️➡️➡️➡️➡️➡️ changes branch:', manifest.changesBranch);
+      console.log('changes branch:', manifest.changesBranch);
       for (const pullRequest of pullRequests) {
         console.log('title:', pullRequest.title.toString());
         console.log('branch:', pullRequest.headRefName);

--- a/src/bin/release-please.ts
+++ b/src/bin/release-please.ts
@@ -175,11 +175,6 @@ function gitHubOptions(yargs: yargs.Argv): yargs.Argv {
       describe: 'The branch to open release PRs against and tag releases on',
       type: 'string',
     })
-    .option('changes-branch', {
-      describe:
-        'The branch where new conventional commits should be looked. Expected to be based on the target-branch',
-      type: 'string',
-    })
     .option('repo-url', {
       describe: 'GitHub URL to generate release for',
       demand: true,
@@ -249,6 +244,11 @@ function pullRequestOptions(yargs: yargs.Argv): yargs.Argv {
       describe: 'should the PR be created from a fork',
       type: 'boolean',
       default: false,
+    })
+    .option('changes-branch', {
+      describe:
+        'If provided, override the branch used to find conventional commits with changes for new version',
+      type: 'string',
     })
     .option('draft-pull-request', {
       describe: 'mark pull request as a draft',
@@ -487,7 +487,7 @@ const createReleasePullRequestCommand: yargs.CommandModule<
       const pullRequests = await manifest.buildPullRequests();
       console.log(`Would open ${pullRequests.length} pull requests`);
       console.log('fork:', manifest.fork);
-      console.log('☢️ changes branch:', manifest.changesBranch);
+      console.log('➡️➡️➡️➡️➡️➡️➡️➡️➡️ changes branch:', manifest.changesBranch);
       for (const pullRequest of pullRequests) {
         console.log('title:', pullRequest.title.toString());
         console.log('branch:', pullRequest.headRefName);

--- a/src/bootstrapper.ts
+++ b/src/bootstrapper.ts
@@ -54,6 +54,7 @@ export class Bootstrapper {
     return await this.github.createPullRequest(
       pullRequest,
       this.targetBranch,
+      this.targetBranch,
       pullRequest.title,
       pullRequest.updates,
       {}

--- a/src/changelog-notes.ts
+++ b/src/changelog-notes.ts
@@ -22,6 +22,7 @@ export interface BuildNotesOptions {
   previousTag?: string;
   currentTag: string;
   targetBranch: string;
+  changesBranch: string;
   changelogSections?: ChangelogSection[];
   commits?: Commit[];
 }

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -62,6 +62,7 @@ export interface StrategyFactoryOptions extends ReleaserConfig {
   github: GitHub;
   path?: string;
   targetBranch?: string;
+  changesBranch?: string;
 }
 
 const releasers: Record<string, ReleaseBuilder> = {
@@ -114,6 +115,7 @@ export async function buildStrategy(
 ): Promise<Strategy> {
   const targetBranch =
     options.targetBranch ?? options.github.repository.defaultBranch;
+  const changesBranch = options.changesBranch || targetBranch;
   const versioningStrategy = buildVersioningStrategy({
     github: options.github,
     type: options.versioning,
@@ -129,6 +131,7 @@ export async function buildStrategy(
     skipGitHubRelease: options.skipGithubRelease, // Note the case difference in GitHub
     ...options,
     targetBranch,
+    changesBranch,
     versioningStrategy,
     changelogNotes,
   };

--- a/src/github.ts
+++ b/src/github.ts
@@ -1169,14 +1169,13 @@ export class GitHub {
         draft: !!options?.draft,
       });
 
-      // const labelsResponse = (
-      //   await this.octokit.issues.addLabels({
-      //     owner: this.repository.owner,
-      //     repo: this.repository.repo,
-      //     issue_number: createResponse.data.number,
-      //     labels: labels,
-      //   })
-      // );
+      // add labels, autorelease labels are needed for the github-release command
+      await this.octokit.issues.addLabels({
+        owner: this.repository.owner,
+        repo: this.repository.repo,
+        issue_number: createPrResponse.data.number,
+        labels: pullRequest.labels,
+      });
 
       // assign reviewers
       if (options?.reviewers) {

--- a/src/github.ts
+++ b/src/github.ts
@@ -65,6 +65,7 @@ export interface GitHubOptions {
   repository: Repository;
   octokitAPIs: OctokitAPIs;
   logger?: Logger;
+  useGraphql?: boolean;
 }
 
 interface ProxyOption {
@@ -82,6 +83,7 @@ interface GitHubCreateOptions {
   token?: string;
   logger?: Logger;
   proxy?: ProxyOption;
+  useGraphql?: boolean;
 }
 
 type CommitFilter = (commit: Commit) => boolean;
@@ -208,6 +210,7 @@ export class GitHub {
   private graphql: Function;
   private fileCache: RepositoryFileCache;
   private logger: Logger;
+  private useGraphql: boolean;
 
   private constructor(options: GitHubOptions) {
     this.repository = options.repository;
@@ -216,6 +219,7 @@ export class GitHub {
     this.graphql = options.octokitAPIs.graphql;
     this.fileCache = new RepositoryFileCache(this.octokit, this.repository);
     this.logger = options.logger ?? defaultLogger;
+    this.useGraphql = options.useGraphql ?? true;
   }
 
   static createDefaultAgent(baseUrl: string, defaultProxy?: ProxyOption) {
@@ -295,6 +299,7 @@ export class GitHub {
       },
       octokitAPIs: apis,
       logger: options.logger,
+      useGraphql: options.useGraphql,
     };
     return new GitHub(opts);
   }
@@ -362,7 +367,18 @@ export class GitHub {
    * @yields {Commit}
    * @throws {GitHubAPIError} on an API error
    */
-  async *mergeCommitIterator(
+  mergeCommitIterator(
+    targetBranch: string,
+    options: CommitIteratorOptions = {}
+  ): AsyncGenerator<Commit> {
+    if (this.useGraphql) {
+      return this.mergeCommitIteratorGraphql(targetBranch, options);
+    }
+
+    return this.mergeCommitIteratorREST(targetBranch, options);
+  }
+
+  private async *mergeCommitIteratorGraphql(
     targetBranch: string,
     options: CommitIteratorOptions = {}
   ) {
@@ -518,6 +534,84 @@ export class GitHub {
       pageInfo: history.pageInfo,
       data: commitData,
     };
+  }
+
+  private async *mergeCommitIteratorREST(
+    targetBranch: string,
+    options: CommitIteratorOptions = {}
+  ): AsyncGenerator<Commit> {
+    const maxResults = options.maxResults ?? Number.MAX_SAFE_INTEGER;
+    let results = 0;
+
+    const iterator = this.octokit.paginate.iterator(
+      this.octokit.rest.repos.listCommits,
+      {
+        owner: this.repository.owner,
+        repo: this.repository.repo,
+        per_page: 25,
+        sha: targetBranch,
+      }
+    );
+
+    for await (const response of iterator) {
+      for (let i = 0; i < response.data.length; i++) {
+        if ((results += 1) > maxResults) {
+          break;
+        }
+
+        const commitData = response.data[i];
+        yield await this.mergeCommitREST(
+          {
+            sha: commitData.sha,
+            message: commitData.commit.message,
+          },
+          options
+        );
+      }
+      if (results > maxResults) {
+        break;
+      }
+    }
+  }
+
+  private async mergeCommitREST(
+    commitData: Commit,
+    options: CommitIteratorOptions
+  ): Promise<Commit> {
+    const commit = {...commitData};
+    if (options.backfillFiles) {
+      commit.files = await this.getCommitFiles(commit.sha);
+    }
+
+    const associatedPRs =
+      await this.octokit.repos.listPullRequestsAssociatedWithCommit({
+        owner: this.repository.owner,
+        repo: this.repository.repo,
+        commit_sha: commit.sha,
+      });
+    if (associatedPRs.data.length) {
+      const pullRequest = associatedPRs.data.find(
+        pr => pr.merge_commit_sha === commit.sha
+      );
+      if (pullRequest) {
+        commit.pullRequest = {
+          sha: commit.sha,
+          number: pullRequest.number,
+          baseBranchName: pullRequest.base.ref,
+          headBranchName: pullRequest.head.ref,
+          title: pullRequest.title,
+          body: pullRequest.body ?? '',
+          labels: pullRequest.labels.map(label => label.name),
+          files: commit.files ?? [],
+        };
+      } else {
+        this.logger.warn(
+          `Found ${associatedPRs.data.length} PRs associated with ${commit.sha} but none matched the commit SHA.`
+        );
+      }
+    }
+
+    return commit;
   }
 
   /**
@@ -808,7 +902,15 @@ export class GitHub {
    * @yields {GitHubRelease}
    * @throws {GitHubAPIError} on an API error
    */
-  async *releaseIterator(options: ReleaseIteratorOptions = {}) {
+  releaseIterator(options: ReleaseIteratorOptions = {}) {
+    if (this.useGraphql) {
+      return this.releaseIteratorGraphql(options);
+    }
+
+    return this.releaseIteratorREST(options);
+  }
+
+  private async *releaseIteratorGraphql(options: ReleaseIteratorOptions) {
     const maxResults = options.maxResults ?? Number.MAX_SAFE_INTEGER;
     let results = 0;
     let cursor: string | undefined = undefined;
@@ -827,6 +929,44 @@ export class GitHub {
         break;
       }
       cursor = response.pageInfo.endCursor;
+    }
+  }
+
+  private async *releaseIteratorREST(
+    options: ReleaseIteratorOptions
+  ): AsyncGenerator<GitHubRelease> {
+    const maxResults = options.maxResults ?? Number.MAX_SAFE_INTEGER;
+    let results = 0;
+
+    const iterator = this.octokit.paginate.iterator(
+      this.octokit.rest.repos.listReleases,
+      {owner: this.repository.owner, repo: this.repository.repo, per_page: 25}
+    );
+
+    for await (const response of iterator) {
+      for (let i = 0; i < response.data.length; i++) {
+        if ((results += 1) > maxResults) {
+          break;
+        }
+
+        const release = response.data[i];
+        const tag = await this.octokit.git.getRef({
+          repo: this.repository.repo,
+          owner: this.repository.owner,
+          ref: `tags/${release.tag_name}`,
+        });
+
+        yield {
+          ...release,
+          tagName: release.tag_name,
+          notes: release.body ?? undefined,
+          name: release.name ?? undefined,
+          sha: tag.data.object.sha,
+        };
+      }
+      if (results > maxResults) {
+        break;
+      }
     }
   }
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -757,6 +757,7 @@ export class Manifest {
       this.plugins.push(
         new Merge(this.github, this.targetBranch, this.repositoryConfig, {
           pullRequestTitlePattern: this.groupPullRequestTitlePattern,
+          changesBranch: this.changesBranch,
         })
       );
     }
@@ -970,6 +971,7 @@ export class Manifest {
         files: [],
       },
       this.targetBranch,
+      this.changesBranch,
       message,
       pullRequest.updates,
       {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -385,7 +385,6 @@ export class Manifest {
    *
    * @param {GitHub} github GitHub client
    * @param {string} targetBranch The releaseable base branch
-   * @param {string} changesBranch Branch containing changes for the new version
    * @param {string} configFile Optional. The path to the manifest config file
    * @param {string} manifestFile Optional. The path to the manifest versions file
    * @param {string} path The single path to check. Optional
@@ -590,10 +589,13 @@ export class Manifest {
     this.logger.info('Collecting commits since all latest releases');
     const commits: Commit[] = [];
     this.logger.debug(`commit search depth: ${this.commitSearchDepth}`);
-    const commitGenerator = this.github.mergeCommitIterator(this.targetBranch, {
-      maxResults: this.commitSearchDepth,
-      backfillFiles: true,
-    });
+    const commitGenerator = this.github.mergeCommitIterator(
+      this.changesBranch,
+      {
+        maxResults: this.commitSearchDepth,
+        backfillFiles: true,
+      }
+    );
     const releaseShas = new Set(Object.values(releaseShasByPath));
     this.logger.debug(releaseShas);
     const expectedShas = releaseShas.size;
@@ -698,6 +700,7 @@ export class Manifest {
       );
       this.logger.debug(`type: ${config.releaseType}`);
       this.logger.debug(`targetBranch: ${this.targetBranch}`);
+      this.logger.debug(`changesBranch: ${this.changesBranch}`);
       let pathCommits = parseConventionalCommits(
         commitsPerPath[path],
         this.logger

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -726,6 +726,10 @@ export class Manifest {
         config.draftPullRequest ?? this.draftPullRequest,
         this.labels
       );
+      this.logger.debug(`path: ${path}`);
+      this.logger.debug(
+        `releasePullRequest.headRefName: ${releasePullRequest?.headRefName}`
+      );
       if (releasePullRequest) {
         // Update manifest, but only for valid release version - this will skip SNAPSHOT from java strategy
         if (
@@ -1233,6 +1237,7 @@ export class Manifest {
           github: this.github,
           path,
           targetBranch: this.targetBranch,
+          changesBranch: this.changesBranch,
         });
         this._strategiesByPath[path] = strategy;
       }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -19,6 +19,11 @@ import {Commit, ConventionalCommit} from './commit';
 import {Release} from './release';
 import {logger as defaultLogger, Logger} from './util/logger';
 
+export interface ManifestPluginOptions {
+  logger?: Logger;
+  changesBranch?: string;
+}
+
 /**
  * A plugin runs after a repository manifest has built candidate
  * pull requests and can make updates that span across multiple
@@ -28,18 +33,20 @@ import {logger as defaultLogger, Logger} from './util/logger';
 export abstract class ManifestPlugin {
   readonly github: GitHub;
   readonly targetBranch: string;
+  readonly changesBranch: string;
   readonly repositoryConfig: RepositoryConfig;
   protected logger: Logger;
   constructor(
     github: GitHub,
     targetBranch: string,
     repositoryConfig: RepositoryConfig,
-    logger: Logger = defaultLogger
+    options: ManifestPluginOptions
   ) {
     this.github = github;
     this.targetBranch = targetBranch;
     this.repositoryConfig = repositoryConfig;
-    this.logger = logger;
+    this.changesBranch = options?.changesBranch || this.targetBranch;
+    this.logger = options.logger || defaultLogger;
   }
 
   /**

--- a/src/plugins/cargo-workspace.ts
+++ b/src/plugins/cargo-workspace.ts
@@ -253,7 +253,10 @@ export class CargoWorkspace extends WorkspacePlugin<CrateInfo> {
       updatedManifest
     );
     const pullRequest: ReleasePullRequest = {
-      title: PullRequestTitle.ofTargetBranch(this.targetBranch),
+      title: PullRequestTitle.ofTargetBranch(
+        this.targetBranch,
+        this.changesBranch
+      ),
       body: new PullRequestBody([
         {
           component: pkg.name,
@@ -281,7 +284,10 @@ export class CargoWorkspace extends WorkspacePlugin<CrateInfo> {
         },
       ],
       labels: [],
-      headRefName: BranchName.ofTargetBranch(this.targetBranch).toString(),
+      headRefName: BranchName.ofTargetBranch(
+        this.targetBranch,
+        this.changesBranch
+      ).toString(),
       version,
       draft: false,
     };

--- a/src/plugins/cargo-workspace.ts
+++ b/src/plugins/cargo-workspace.ts
@@ -87,7 +87,7 @@ export class CargoWorkspace extends WorkspacePlugin<CrateInfo> {
   }> {
     const cargoManifestContent = await this.github.getFileContentsOnBranch(
       'Cargo.toml',
-      this.targetBranch
+      this.changesBranch
     );
     const cargoManifest = parseCargoManifest(
       cargoManifestContent.parsedContent
@@ -105,7 +105,7 @@ export class CargoWorkspace extends WorkspacePlugin<CrateInfo> {
     const members = (
       await Promise.all(
         cargoManifest.workspace.members.map(member =>
-          this.github.findFilesByGlobAndRef(member, this.targetBranch)
+          this.github.findFilesByGlobAndRef(member, this.changesBranch)
         )
       )
     ).flat();
@@ -122,7 +122,7 @@ export class CargoWorkspace extends WorkspacePlugin<CrateInfo> {
         )?.cachedFileContents ||
         (await this.github.getFileContentsOnBranch(
           manifestPath,
-          this.targetBranch
+          this.changesBranch
         ));
       const manifest = parseCargoManifest(manifestContent.parsedContent);
       const packageName = manifest.package?.name;

--- a/src/plugins/group-priority.ts
+++ b/src/plugins/group-priority.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ManifestPlugin} from '../plugin';
+import {ManifestPlugin, ManifestPluginOptions} from '../plugin';
 import {GitHub} from '../github';
 import {RepositoryConfig, CandidateReleasePullRequest} from '../manifest';
 
@@ -36,9 +36,10 @@ export class GroupPriority extends ManifestPlugin {
     github: GitHub,
     targetBranch: string,
     repositoryConfig: RepositoryConfig,
-    groups: string[]
+    groups: string[],
+    options: ManifestPluginOptions = {}
   ) {
-    super(github, targetBranch, repositoryConfig);
+    super(github, targetBranch, repositoryConfig, options);
     this.groups = groups;
   }
 

--- a/src/plugins/linked-versions.ts
+++ b/src/plugins/linked-versions.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ManifestPlugin} from '../plugin';
+import {ManifestPlugin, ManifestPluginOptions} from '../plugin';
 import {RepositoryConfig, CandidateReleasePullRequest} from '../manifest';
 import {GitHub} from '../github';
 import {Logger} from '../util/logger';
@@ -24,9 +24,8 @@ import {buildStrategy} from '../factory';
 import {Merge} from './merge';
 import {BranchName} from '../util/branch-name';
 
-interface LinkedVersionsPluginOptions {
+interface LinkedVersionsPluginOptions extends ManifestPluginOptions {
   merge?: boolean;
-  logger?: Logger;
 }
 
 /**
@@ -48,7 +47,7 @@ export class LinkedVersions extends ManifestPlugin {
     components: string[],
     options: LinkedVersionsPluginOptions = {}
   ) {
-    super(github, targetBranch, repositoryConfig, options.logger);
+    super(github, targetBranch, repositoryConfig, options);
     this.groupName = groupName;
     this.components = new Set(components);
     this.merge = options.merge ?? true;

--- a/src/plugins/linked-versions.ts
+++ b/src/plugins/linked-versions.ts
@@ -181,7 +181,8 @@ export class LinkedVersions extends ManifestPlugin {
           forceMerge: true,
           headBranchName: BranchName.ofGroupTargetBranch(
             this.groupName,
-            this.targetBranch
+            this.targetBranch,
+            this.changesBranch
           ).toString(),
         }
       );

--- a/src/plugins/maven-workspace.ts
+++ b/src/plugins/maven-workspace.ts
@@ -410,7 +410,10 @@ export class MavenWorkspace extends WorkspacePlugin<MavenArtifact> {
       this.logger
     );
     const pullRequest: ReleasePullRequest = {
-      title: PullRequestTitle.ofTargetBranch(this.targetBranch),
+      title: PullRequestTitle.ofTargetBranch(
+        this.targetBranch,
+        this.changesBranch
+      ),
       body: new PullRequestBody([
         {
           component: artifact.name,
@@ -438,7 +441,10 @@ export class MavenWorkspace extends WorkspacePlugin<MavenArtifact> {
         },
       ],
       labels: [],
-      headRefName: BranchName.ofTargetBranch(this.targetBranch).toString(),
+      headRefName: BranchName.ofTargetBranch(
+        this.targetBranch,
+        this.changesBranch
+      ).toString(),
       version,
       draft: false,
     };

--- a/src/plugins/merge.ts
+++ b/src/plugins/merge.ts
@@ -99,10 +99,10 @@ export class Merge extends ManifestPlugin {
     const updates = mergeUpdates(rawUpdates);
 
     const pullRequest = {
-      title: PullRequestTitle.ofComponentChangesBranchTargetBranchVersion(
+      title: PullRequestTitle.ofComponentTargetBranchVersion(
         rootRelease?.pullRequest.title.component,
-        this.changesBranch,
         this.targetBranch,
+        this.changesBranch,
         rootRelease?.pullRequest.title.version,
         this.pullRequestTitlePattern
       ),
@@ -113,12 +113,11 @@ export class Merge extends ManifestPlugin {
       updates,
       labels: Array.from(labels),
       headRefName:
-        this.headBranchName ?? this.changesBranch !== this.targetBranch
-          ? BranchName.ofChangesBranchTargetBranch(
-              this.changesBranch,
-              this.targetBranch
-            ).toString()
-          : BranchName.ofTargetBranch(this.targetBranch).toString(),
+        this.headBranchName ??
+        BranchName.ofTargetBranch(
+          this.targetBranch,
+          this.changesBranch
+        ).toString(),
       draft: !candidates.some(candidate => !candidate.pullRequest.draft),
     };
 

--- a/src/plugins/node-workspace.ts
+++ b/src/plugins/node-workspace.ts
@@ -268,7 +268,10 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
     const packageJson = updatedPackage.toJSON() as PackageJson;
     const version = Version.parse(packageJson.version);
     const pullRequest: ReleasePullRequest = {
-      title: PullRequestTitle.ofTargetBranch(this.targetBranch),
+      title: PullRequestTitle.ofTargetBranch(
+        this.targetBranch,
+        this.changesBranch
+      ),
       body: new PullRequestBody([
         {
           component: updatedPackage.name,
@@ -302,7 +305,10 @@ export class NodeWorkspace extends WorkspacePlugin<Package> {
         },
       ],
       labels: [],
-      headRefName: BranchName.ofTargetBranch(this.targetBranch).toString(),
+      headRefName: BranchName.ofTargetBranch(
+        this.targetBranch,
+        this.changesBranch
+      ).toString(),
       version,
       draft: false,
     };

--- a/src/plugins/sentence-case.ts
+++ b/src/plugins/sentence-case.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ManifestPlugin} from '../plugin';
+import {ManifestPlugin, ManifestPluginOptions} from '../plugin';
 import {GitHub} from '../github';
 import {RepositoryConfig} from '../manifest';
 import {ConventionalCommit} from '../commit';
@@ -30,9 +30,10 @@ export class SentenceCase extends ManifestPlugin {
     github: GitHub,
     targetBranch: string,
     repositoryConfig: RepositoryConfig,
-    specialWords?: Array<string>
+    specialWords?: Array<string>,
+    options: ManifestPluginOptions = {}
   ) {
-    super(github, targetBranch, repositoryConfig);
+    super(github, targetBranch, repositoryConfig, options);
     this.specialWords = new Set(
       specialWords ? [...specialWords] : SPECIAL_WORDS
     );

--- a/src/plugins/workspace.ts
+++ b/src/plugins/workspace.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {ManifestPlugin} from '../plugin';
+import {ManifestPlugin, ManifestPluginOptions} from '../plugin';
 import {
   CandidateReleasePullRequest,
   RepositoryConfig,
@@ -31,11 +31,10 @@ export interface DependencyNode<T> {
   value: T;
 }
 
-export interface WorkspacePluginOptions {
+export interface WorkspacePluginOptions extends ManifestPluginOptions {
   manifestPath?: string;
   updateAllPackages?: boolean;
   merge?: boolean;
-  logger?: Logger;
 }
 
 export interface AllPackages<T> {
@@ -64,7 +63,7 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
     repositoryConfig: RepositoryConfig,
     options: WorkspacePluginOptions = {}
   ) {
-    super(github, targetBranch, repositoryConfig, options.logger);
+    super(github, targetBranch, repositoryConfig, options);
     this.manifestPath = options.manifestPath ?? DEFAULT_RELEASE_PLEASE_MANIFEST;
     this.updateAllPackages = options.updateAllPackages ?? false;
     this.merge = options.merge ?? true;

--- a/src/pull-request.ts
+++ b/src/pull-request.ts
@@ -15,6 +15,7 @@
 export interface PullRequest {
   readonly headBranchName: string;
   readonly baseBranchName: string;
+  // readonly changesBranchName: string;
   readonly number: number;
   readonly title: string;
   readonly body: string;

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -217,6 +217,7 @@ export abstract class BaseStrategy implements Strategy {
       previousTag: latestRelease?.tag?.toString(),
       currentTag: newVersionTag.toString(),
       targetBranch: this.targetBranch,
+      changesBranch: this.changesBranch,
       changelogSections: this.changelogSections,
       commits: commits,
     });
@@ -284,40 +285,28 @@ export abstract class BaseStrategy implements Strategy {
       this.tagSeparator,
       this.includeVInTag
     );
+
     this.logger.debug(
       'pull request title pattern:',
       this.pullRequestTitlePattern
     );
-    const pullRequestTitle =
-      this.targetBranch == this.changesBranch
-        ? PullRequestTitle.ofComponentTargetBranchVersion(
-            component || '',
-            this.targetBranch,
-            newVersion,
-            this.pullRequestTitlePattern
-          )
-        : PullRequestTitle.ofComponentChangesBranchTargetBranchVersion(
-            component || '',
-            this.changesBranch,
-            this.targetBranch,
-            newVersion,
-            this.pullRequestTitlePattern
-          );
+    const pullRequestTitle = PullRequestTitle.ofComponentTargetBranchVersion(
+      component || '',
+      this.targetBranch,
+      this.changesBranch,
+      newVersion,
+      this.pullRequestTitlePattern
+    );
+
     const branchComponent = await this.getBranchComponent();
     const branchName = branchComponent
-      ? this.targetBranch == this.changesBranch
-        ? BranchName.ofComponentTargetBranch(branchComponent, this.targetBranch)
-        : BranchName.ofComponentChangesBranchTargetBranch(
-            branchComponent,
-            this.changesBranch,
-            this.targetBranch
-          )
-      : this.targetBranch == this.changesBranch
-      ? BranchName.ofTargetBranch(this.targetBranch)
-      : BranchName.ofChangesBranchTargetBranch(
-          this.changesBranch,
-          this.targetBranch
-        );
+      ? BranchName.ofComponentTargetBranch(
+          branchComponent,
+          this.targetBranch,
+          this.changesBranch
+        )
+      : BranchName.ofTargetBranch(this.targetBranch, this.changesBranch);
+
     const releaseNotesBody = await this.buildReleaseNotes(
       conventionalCommits,
       newVersion,

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -61,6 +61,7 @@ export interface BaseStrategyOptions {
   packageName?: string;
   versioningStrategy?: VersioningStrategy;
   targetBranch: string;
+  changesBranch?: string;
   changelogPath?: string;
   changelogHost?: string;
   changelogSections?: ChangelogSection[];
@@ -96,6 +97,7 @@ export abstract class BaseStrategy implements Strategy {
   private packageName?: string;
   readonly versioningStrategy: VersioningStrategy;
   protected targetBranch: string;
+  protected changesBranch: string;
   protected repository: Repository;
   protected changelogPath: string;
   protected changelogHost?: string;
@@ -126,6 +128,7 @@ export abstract class BaseStrategy implements Strategy {
       options.versioningStrategy ||
       new DefaultVersioningStrategy({logger: this.logger});
     this.targetBranch = options.targetBranch;
+    this.changesBranch = options.changesBranch || this.targetBranch;
     this.repository = options.github.repository;
     this.changelogPath = options.changelogPath || DEFAULT_CHANGELOG_PATH;
     this.changelogHost = options.changelogHost;
@@ -285,16 +288,36 @@ export abstract class BaseStrategy implements Strategy {
       'pull request title pattern:',
       this.pullRequestTitlePattern
     );
-    const pullRequestTitle = PullRequestTitle.ofComponentTargetBranchVersion(
-      component || '',
-      this.targetBranch,
-      newVersion,
-      this.pullRequestTitlePattern
-    );
+    const pullRequestTitle =
+      this.targetBranch == this.changesBranch
+        ? PullRequestTitle.ofComponentTargetBranchVersion(
+            component || '',
+            this.targetBranch,
+            newVersion,
+            this.pullRequestTitlePattern
+          )
+        : PullRequestTitle.ofComponentChangesBranchTargetBranchVersion(
+            component || '',
+            this.changesBranch,
+            this.targetBranch,
+            newVersion,
+            this.pullRequestTitlePattern
+          );
     const branchComponent = await this.getBranchComponent();
     const branchName = branchComponent
-      ? BranchName.ofComponentTargetBranch(branchComponent, this.targetBranch)
-      : BranchName.ofTargetBranch(this.targetBranch);
+      ? this.targetBranch == this.changesBranch
+        ? BranchName.ofComponentTargetBranch(branchComponent, this.targetBranch)
+        : BranchName.ofComponentChangesBranchTargetBranch(
+            branchComponent,
+            this.changesBranch,
+            this.targetBranch
+          )
+      : this.targetBranch == this.changesBranch
+      ? BranchName.ofTargetBranch(this.targetBranch)
+      : BranchName.ofChangesBranchTargetBranch(
+          this.changesBranch,
+          this.targetBranch
+        );
     const releaseNotesBody = await this.buildReleaseNotes(
       conventionalCommits,
       newVersion,
@@ -356,20 +379,20 @@ export abstract class BaseStrategy implements Strategy {
       return (
         await this.github.findFilesByGlobAndRef(
           extraFile.path.slice(1),
-          this.targetBranch
+          this.changesBranch
         )
       ).map(file => `/${file}`);
     } else if (this.path === ROOT_PROJECT_PATH) {
       // root component, ignore path prefix
       return this.github.findFilesByGlobAndRef(
         extraFile.path,
-        this.targetBranch
+        this.changesBranch
       );
     } else {
       // glob is relative to current path
       return this.github.findFilesByGlobAndRef(
         extraFile.path,
-        this.targetBranch,
+        this.changesBranch,
         this.path
       );
     }

--- a/src/strategies/dart.ts
+++ b/src/strategies/dart.ts
@@ -68,7 +68,7 @@ export class Dart extends BaseStrategy {
       try {
         this.pubspecYmlContents = await this.github.getFileContentsOnBranch(
           this.addPath('pubspec.yaml'),
-          this.targetBranch
+          this.changesBranch
         );
       } catch (e) {
         if (e instanceof FileNotFoundError) {

--- a/src/strategies/dotnet-yoshi.ts
+++ b/src/strategies/dotnet-yoshi.ts
@@ -87,7 +87,7 @@ export class DotnetYoshi extends BaseStrategy {
     try {
       const contents = await this.github.getFileContentsOnBranch(
         'apis/apis.json',
-        this.targetBranch
+        this.changesBranch
       );
       const apis = JSON.parse(contents.parsedContent) as ApisJsonConfiguration;
       const component = await this.getComponent();

--- a/src/strategies/go-yoshi.ts
+++ b/src/strategies/go-yoshi.ts
@@ -168,7 +168,7 @@ export class GoYoshi extends BaseStrategy {
 
     this.logger.info('Looking for go.mod files');
     const paths = (
-      await this.github.findFilesByFilenameAndRef('go.mod', this.targetBranch)
+      await this.github.findFilesByFilenameAndRef('go.mod', this.changesBranch)
     )
       .filter(path => !path.includes('internal') && path !== 'go.mod')
       .map(path => dirname(path));

--- a/src/strategies/java-yoshi-mono-repo.ts
+++ b/src/strategies/java-yoshi-mono-repo.ts
@@ -77,7 +77,7 @@ export class JavaYoshiMonoRepo extends Java {
       try {
         this.versionsContent = await this.github.getFileContentsOnBranch(
           this.addPath('versions.txt'),
-          this.targetBranch
+          this.changesBranch
         );
       } catch (err) {
         if (err instanceof GitHubAPIError) {
@@ -112,22 +112,22 @@ export class JavaYoshiMonoRepo extends Java {
 
     const pomFilesSearch = this.github.findFilesByFilenameAndRef(
       'pom.xml',
-      this.targetBranch,
+      this.changesBranch,
       this.path
     );
     const buildFilesSearch = this.github.findFilesByFilenameAndRef(
       'build.gradle',
-      this.targetBranch,
+      this.changesBranch,
       this.path
     );
     const dependenciesSearch = this.github.findFilesByFilenameAndRef(
       'dependencies.properties',
-      this.targetBranch,
+      this.changesBranch,
       this.path
     );
     const readmeFilesSearch = this.github.findFilesByFilenameAndRef(
       'README.md',
-      this.targetBranch,
+      this.changesBranch,
       this.path
     );
 
@@ -254,7 +254,7 @@ export class JavaYoshiMonoRepo extends Java {
     try {
       const content = await this.github.getFileContentsOnBranch(
         'changelog.json',
-        this.targetBranch
+        this.changesBranch
       );
       return !!content;
     } catch (e) {
@@ -269,7 +269,7 @@ export class JavaYoshiMonoRepo extends Java {
     try {
       const content = await this.github.getFileContentsOnBranch(
         this.addPath(`${path}/.repo-metadata.json`),
-        this.targetBranch
+        this.changesBranch
       );
       return content ? JSON.parse(content.parsedContent) : null;
     } catch (e) {

--- a/src/strategies/java-yoshi.ts
+++ b/src/strategies/java-yoshi.ts
@@ -67,7 +67,7 @@ export class JavaYoshi extends Java {
       try {
         this.versionsContent = await this.github.getFileContentsOnBranch(
           this.addPath('versions.txt'),
-          this.targetBranch
+          this.changesBranch
         );
       } catch (err) {
         if (err instanceof FileNotFoundError) {
@@ -102,17 +102,17 @@ export class JavaYoshi extends Java {
 
     const pomFilesSearch = this.github.findFilesByFilenameAndRef(
       'pom.xml',
-      this.targetBranch,
+      this.changesBranch,
       this.path
     );
     const buildFilesSearch = this.github.findFilesByFilenameAndRef(
       'build.gradle',
-      this.targetBranch,
+      this.changesBranch,
       this.path
     );
     const dependenciesSearch = this.github.findFilesByFilenameAndRef(
       'dependencies.properties',
-      this.targetBranch,
+      this.changesBranch,
       this.path
     );
 

--- a/src/strategies/java.ts
+++ b/src/strategies/java.ts
@@ -115,11 +115,16 @@ export class Java extends BaseStrategy {
     const pullRequestTitle = PullRequestTitle.ofComponentTargetBranchVersion(
       component || '',
       this.targetBranch,
+      this.changesBranch,
       newVersion
     );
     const branchName = component
-      ? BranchName.ofComponentTargetBranch(component, this.targetBranch)
-      : BranchName.ofTargetBranch(this.targetBranch);
+      ? BranchName.ofComponentTargetBranch(
+          component,
+          this.targetBranch,
+          this.changesBranch
+        )
+      : BranchName.ofTargetBranch(this.targetBranch, this.changesBranch);
     const notes =
       '### Updating meta-information for bleeding-edge SNAPSHOT release.';
     // TODO use pullrequest header here?

--- a/src/strategies/krm-blueprint.ts
+++ b/src/strategies/krm-blueprint.ts
@@ -50,7 +50,7 @@ export class KRMBlueprint extends BaseStrategy {
     // Update version in all yaml files with attribution annotation
     const yamlPaths = await this.github.findFilesByExtensionAndRef(
       'yaml',
-      this.targetBranch,
+      this.changesBranch,
       this.path
     );
     for (const yamlPath of yamlPaths) {

--- a/src/strategies/maven.ts
+++ b/src/strategies/maven.ts
@@ -35,7 +35,7 @@ export class Maven extends Java {
     // Update pom.xml files
     const pomFiles = await this.github.findFilesByFilenameAndRef(
       'pom.xml',
-      this.targetBranch,
+      this.changesBranch,
       this.path
     );
 

--- a/src/strategies/node.ts
+++ b/src/strategies/node.ts
@@ -106,7 +106,7 @@ export class Node extends BaseStrategy {
       try {
         this.pkgJsonContents = await this.github.getFileContentsOnBranch(
           this.addPath('package.json'),
-          this.targetBranch
+          this.changesBranch
         );
       } catch (e) {
         if (e instanceof FileNotFoundError) {

--- a/src/strategies/php-yoshi.ts
+++ b/src/strategies/php-yoshi.ts
@@ -96,12 +96,12 @@ export class PHPYoshi extends BaseStrategy {
       try {
         const contents = await this.github.getFileContentsOnBranch(
           this.addPath(`${directory}/VERSION`),
-          this.targetBranch
+          this.changesBranch
         );
         const version = Version.parse(contents.parsedContent);
         const composer = await this.github.getFileJson<ComposerJson>(
           this.addPath(`${directory}/composer.json`),
-          this.targetBranch
+          this.changesBranch
         );
         directoryVersionContents[directory] = {
           versionContents: contents,
@@ -122,6 +122,7 @@ export class PHPYoshi extends BaseStrategy {
             previousTag: latestRelease?.tag?.toString(),
             currentTag: newVersionTag.toString(),
             targetBranch: this.targetBranch,
+            changesBranch: this.changesBranch,
             changelogSections: this.changelogSections,
           }
         );
@@ -140,14 +141,21 @@ export class PHPYoshi extends BaseStrategy {
         }
       }
     }
+
     const pullRequestTitle = PullRequestTitle.ofComponentTargetBranchVersion(
       component || '',
       this.targetBranch,
+      this.changesBranch,
       newVersion
     );
     const branchName = component
-      ? BranchName.ofComponentTargetBranch(component, this.targetBranch)
-      : BranchName.ofTargetBranch(this.targetBranch);
+      ? BranchName.ofComponentTargetBranch(
+          component,
+          this.targetBranch,
+          this.changesBranch
+        )
+      : BranchName.ofTargetBranch(this.targetBranch, this.changesBranch);
+
     const updates = await this.buildUpdates({
       changelogEntry: releaseNotesBody,
       newVersion,

--- a/src/strategies/python.ts
+++ b/src/strategies/python.ts
@@ -122,7 +122,7 @@ export class Python extends BaseStrategy {
     // There should be only one version.py, but foreach in case that is incorrect
     const versionPyFilesSearch = this.github.findFilesByFilenameAndRef(
       'version.py',
-      this.targetBranch,
+      this.changesBranch,
       this.path
     );
     const versionPyFiles = await versionPyFilesSearch;
@@ -159,7 +159,7 @@ export class Python extends BaseStrategy {
     try {
       const content = await this.github.getFileContentsOnBranch(
         path,
-        this.targetBranch
+        this.changesBranch
       );
       return parsePyProject(content.parsedContent);
     } catch (e) {
@@ -184,7 +184,7 @@ export class Python extends BaseStrategy {
       return (
         await this.github.getFileContentsOnBranch(
           this.addPath('setup.py'),
-          this.targetBranch
+          this.changesBranch
         )
       ).parsedContent;
     } catch (e) {

--- a/src/strategies/rust.ts
+++ b/src/strategies/rust.ts
@@ -155,7 +155,7 @@ export class Rust extends BaseStrategy {
     try {
       return await this.github.getFileContentsOnBranch(
         this.addPath(path),
-        this.targetBranch
+        this.changesBranch
       );
     } catch (e) {
       return null;

--- a/src/strategies/sfdx.ts
+++ b/src/strategies/sfdx.ts
@@ -63,7 +63,7 @@ export class Sfdx extends BaseStrategy {
         this.sfdxProjectJsonContents =
           await this.github.getFileContentsOnBranch(
             this.addPath(sfdxProjectJsonFileName),
-            this.targetBranch
+            this.changesBranch
           );
       } catch (e) {
         if (e instanceof FileNotFoundError) {

--- a/src/strategies/terraform-module.ts
+++ b/src/strategies/terraform-module.ts
@@ -42,12 +42,12 @@ export class TerraformModule extends BaseStrategy {
     const readmeFiles = await Promise.all([
       this.github.findFilesByFilenameAndRef(
         'readme.md',
-        this.targetBranch,
+        this.changesBranch,
         this.path
       ),
       this.github.findFilesByFilenameAndRef(
         'README.md',
-        this.targetBranch,
+        this.changesBranch,
         this.path
       ),
     ]).then(([v, vt]) => {
@@ -68,12 +68,12 @@ export class TerraformModule extends BaseStrategy {
     const versionFiles = await Promise.all([
       this.github.findFilesByFilenameAndRef(
         'versions.tf',
-        this.targetBranch,
+        this.changesBranch,
         this.path
       ),
       this.github.findFilesByFilenameAndRef(
         'versions.tf.tmpl',
-        this.targetBranch,
+        this.changesBranch,
         this.path
       ),
     ]).then(([v, vt]) => {

--- a/src/util/branch-name.ts
+++ b/src/util/branch-name.ts
@@ -29,6 +29,7 @@ function getAllResourceNames(): BranchNameType[] {
     AutoreleaseBranchName,
     ComponentBranchName,
     GroupBranchName,
+    ChangesBranchName,
     DefaultBranchName,
     V12ComponentBranchName,
     V12DefaultBranchName,
@@ -38,6 +39,7 @@ function getAllResourceNames(): BranchNameType[] {
 export class BranchName {
   component?: string;
   targetBranch?: string;
+  changesBranch?: string;
   version?: Version;
 
   static parse(
@@ -71,6 +73,14 @@ export class BranchName {
       `${RELEASE_PLEASE}--branches--${targetBranch}`
     );
   }
+  static ofChangesTargetBranch(
+    changesBranch: string,
+    targetBranch: string
+  ): BranchName {
+    return new ComponentBranchName(
+      `${RELEASE_PLEASE}--branches--${targetBranch}--changes--${changesBranch}`
+    );
+  }
   static ofComponentTargetBranch(
     component: string,
     targetBranch: string
@@ -93,6 +103,9 @@ export class BranchName {
   }
   getTargetBranch(): string | undefined {
     return this.targetBranch;
+  }
+  getChangesBranch(): string | undefined {
+    return this.changesBranch;
   }
   getComponent(): string | undefined {
     return this.component;
@@ -199,6 +212,24 @@ class DefaultBranchName extends BranchName {
   }
   toString(): string {
     return `${RELEASE_PLEASE}--branches--${this.targetBranch}`;
+  }
+}
+
+const CHANGES_PATTERN = `^${RELEASE_PLEASE}--branches--(?<branch>.+)--changes--(?<changesBranch>.+)$`;
+class ChangesBranchName extends BranchName {
+  static matches(branchName: string): boolean {
+    return !!branchName.match(CHANGES_PATTERN);
+  }
+  constructor(branchName: string) {
+    super(branchName);
+    const match = branchName.match(CHANGES_PATTERN);
+    if (match?.groups) {
+      this.targetBranch = match.groups['branch'];
+      this.changesBranch = match.groups['changesBranch'];
+    }
+  }
+  toString(): string {
+    return `${RELEASE_PLEASE}--branches--${this.targetBranch}--changes--${this.changesBranch}`;
   }
 }
 

--- a/src/util/branch-name.ts
+++ b/src/util/branch-name.ts
@@ -68,39 +68,38 @@ export class BranchName {
   static ofVersion(version: Version): BranchName {
     return new AutoreleaseBranchName(`release-v${version}`);
   }
-  static ofTargetBranch(targetBranch: string): BranchName {
-    return new DefaultBranchName(
-      `${RELEASE_PLEASE}--branches--${targetBranch}`
-    );
-  }
-  static ofChangesBranchTargetBranch(
-    changesBranch: string,
-    targetBranch: string
+  static ofTargetBranch(
+    targetBranch: string,
+    changesBranch: string
   ): BranchName {
-    return new ComponentBranchName(
-      `${RELEASE_PLEASE}--branches--${targetBranch}--changes--${changesBranch}`
+    const changes =
+      targetBranch === changesBranch ? '' : `--changes--${changesBranch}`;
+    return new DefaultBranchName(
+      `${RELEASE_PLEASE}--branches--${targetBranch}${changes}`
     );
   }
+
   static ofComponentTargetBranch(
     component: string,
-    targetBranch: string
+    targetBranch: string,
+    changesBranch: string
   ): BranchName {
+    const changes =
+      targetBranch === changesBranch ? '' : `--changes--${changesBranch}`;
     return new ComponentBranchName(
-      `${RELEASE_PLEASE}--branches--${targetBranch}--components--${component}`
+      `${RELEASE_PLEASE}--branches--${targetBranch}${changes}--components--${component}`
     );
   }
-  static ofComponentChangesBranchTargetBranch(
-    component: string,
-    changesBranch: string,
-    targetBranch: string
+
+  static ofGroupTargetBranch(
+    group: string,
+    targetBranch: string,
+    changesBranch: string
   ): BranchName {
-    return new ComponentBranchName(
-      `${RELEASE_PLEASE}--branches--${targetBranch}--changes--${changesBranch}--components--${component}`
-    );
-  }
-  static ofGroupTargetBranch(group: string, targetBranch: string): BranchName {
+    const changes =
+      targetBranch === changesBranch ? '' : `--changes--${changesBranch}`;
     return new GroupBranchName(
-      `${RELEASE_PLEASE}--branches--${targetBranch}--groups--${safeBranchName(
+      `${RELEASE_PLEASE}--branches--${targetBranch}${changes}--groups--${safeBranchName(
         group
       )}`
     );

--- a/src/util/branch-name.ts
+++ b/src/util/branch-name.ts
@@ -73,7 +73,7 @@ export class BranchName {
       `${RELEASE_PLEASE}--branches--${targetBranch}`
     );
   }
-  static ofChangesTargetBranch(
+  static ofChangesBranchTargetBranch(
     changesBranch: string,
     targetBranch: string
   ): BranchName {
@@ -87,6 +87,15 @@ export class BranchName {
   ): BranchName {
     return new ComponentBranchName(
       `${RELEASE_PLEASE}--branches--${targetBranch}--components--${component}`
+    );
+  }
+  static ofComponentChangesBranchTargetBranch(
+    component: string,
+    changesBranch: string,
+    targetBranch: string
+  ): BranchName {
+    return new ComponentBranchName(
+      `${RELEASE_PLEASE}--branches--${targetBranch}--changes--${changesBranch}--components--${component}`
     );
   }
   static ofGroupTargetBranch(group: string, targetBranch: string): BranchName {
@@ -215,7 +224,10 @@ class DefaultBranchName extends BranchName {
   }
 }
 
+// TODO: likely to be simpler to merge the pattern and ChangesBranchName class with DefaultBranchName,
+// with the changesBranch section made optional.
 const CHANGES_PATTERN = `^${RELEASE_PLEASE}--branches--(?<branch>.+)--changes--(?<changesBranch>.+)$`;
+
 class ChangesBranchName extends BranchName {
   static matches(branchName: string): boolean {
     return !!branchName.match(CHANGES_PATTERN);

--- a/src/util/pull-request-title.ts
+++ b/src/util/pull-request-title.ts
@@ -133,7 +133,7 @@ export class PullRequestTitle {
       pullRequestTitlePattern,
     });
   }
-  static ofChangesTargetBranchVersion(
+  static ofChangesBranchTargetBranchVersion(
     changesBranch?: string,
     targetBranch?: string,
     version?: Version,
@@ -159,6 +159,23 @@ export class PullRequestTitle {
       pullRequestTitlePattern,
     });
   }
+
+  static ofComponentChangesBranchTargetBranchVersion(
+    component?: string,
+    changesBranch?: string,
+    targetBranch?: string,
+    version?: Version,
+    pullRequestTitlePattern?: string
+  ): PullRequestTitle {
+    return new PullRequestTitle({
+      version,
+      component,
+      changesBranch,
+      targetBranch,
+      pullRequestTitlePattern,
+    });
+  }
+
   static ofTargetBranch(
     targetBranch: string,
     pullRequestTitlePattern?: string
@@ -184,7 +201,7 @@ export class PullRequestTitle {
 
   toString(): string {
     const scope = this.targetBranch
-      ? this.changesBranch
+      ? this.changesBranch && this.changesBranch !== this.targetBranch
         ? `(${this.changesBranch} => ${this.targetBranch})`
         : `(${this.targetBranch})`
       : '';

--- a/src/util/pull-request-title.ts
+++ b/src/util/pull-request-title.ts
@@ -28,18 +28,14 @@ export function generateMatchPattern(
   if (
     pullRequestTitlePattern &&
     pullRequestTitlePattern.search(/\$\{scope\}/) === -1
-  )
+  ) {
     logger.warn("pullRequestTitlePattern miss the part of '${scope}'");
+  }
   if (
     pullRequestTitlePattern &&
     pullRequestTitlePattern.search(/\$\{component\}/) === -1
   )
     logger.warn("pullRequestTitlePattern miss the part of '${component}'");
-  if (
-    pullRequestTitlePattern &&
-    pullRequestTitlePattern.search(/\$\{changesBranch\}/) === -1
-  )
-    logger.warn("pullRequestTitlePattern miss the part of '${changesBranch}'");
   if (
     pullRequestTitlePattern &&
     pullRequestTitlePattern.search(/\$\{version\}/) === -1
@@ -51,7 +47,10 @@ export function generateMatchPattern(
       .replace(']', '\\]')
       .replace('(', '\\(')
       .replace(')', '\\)')
-      .replace('${scope}', '(\\((?<branch>[\\w-./]+)\\))?')
+      .replace(
+        '${scope}',
+        '(\\((?<changesBranch>[\\w-./]+ => )?(?<branch>[\\w-./]+)\\))?'
+      )
       .replace('${component}', ' ?(?<component>@?[\\w-./]*)?')
       .replace('${version}', 'v?(?<version>[0-9].*)')
       .replace('${changesBranch}', '(?<changesBranch>?[\\w-./]+)?')
@@ -70,15 +69,15 @@ export class PullRequestTitle {
   private constructor(opts: {
     version?: Version;
     component?: string;
-    changesBranch?: string;
     targetBranch?: string;
+    changesBranch?: string;
     pullRequestTitlePattern?: string;
     logger?: Logger;
   }) {
     this.version = opts.version;
     this.component = opts.component;
-    this.changesBranch = opts.changesBranch;
     this.targetBranch = opts.targetBranch;
+    this.changesBranch = opts.changesBranch || this.targetBranch;
     this.pullRequestTitlePattern =
       opts.pullRequestTitlePattern || DEFAULT_PR_TITLE_PATTERN;
     this.matchPattern = generateMatchPattern(

--- a/src/util/pull-request-title.ts
+++ b/src/util/pull-request-title.ts
@@ -124,64 +124,42 @@ export class PullRequestTitle {
   }
   static ofTargetBranchVersion(
     targetBranch: string,
+    changesBranch: string,
     version: Version,
     pullRequestTitlePattern?: string
   ): PullRequestTitle {
     return new PullRequestTitle({
       version,
       targetBranch,
-      pullRequestTitlePattern,
-    });
-  }
-  static ofChangesBranchTargetBranchVersion(
-    changesBranch?: string,
-    targetBranch?: string,
-    version?: Version,
-    pullRequestTitlePattern?: string
-  ): PullRequestTitle {
-    return new PullRequestTitle({
-      version,
       changesBranch,
-      targetBranch,
-      pullRequestTitlePattern,
-    });
-  }
-  static ofComponentTargetBranchVersion(
-    component?: string,
-    targetBranch?: string,
-    version?: Version,
-    pullRequestTitlePattern?: string
-  ): PullRequestTitle {
-    return new PullRequestTitle({
-      version,
-      component,
-      targetBranch,
       pullRequestTitlePattern,
     });
   }
 
-  static ofComponentChangesBranchTargetBranchVersion(
+  static ofComponentTargetBranchVersion(
     component?: string,
-    changesBranch?: string,
     targetBranch?: string,
+    changesBranch?: string,
     version?: Version,
     pullRequestTitlePattern?: string
   ): PullRequestTitle {
     return new PullRequestTitle({
       version,
       component,
-      changesBranch,
       targetBranch,
+      changesBranch,
       pullRequestTitlePattern,
     });
   }
 
   static ofTargetBranch(
     targetBranch: string,
+    changesBranch: string,
     pullRequestTitlePattern?: string
   ): PullRequestTitle {
     return new PullRequestTitle({
       targetBranch,
+      changesBranch,
       pullRequestTitlePattern,
     });
   }

--- a/test/bootstrapper.ts
+++ b/test/bootstrapper.ts
@@ -68,7 +68,7 @@ describe('Bootstrapper', () => {
       sinon.match.array,
       sinon.match.any
     );
-    const updates = createPullRequestStub.firstCall.args[3];
+    const updates = createPullRequestStub.firstCall.args[4];
     assertHasUpdate(
       updates,
       '.release-please-manifest.json',

--- a/test/changelog-notes/default-changelog-notes.ts
+++ b/test/changelog-notes/default-changelog-notes.ts
@@ -68,6 +68,7 @@ describe('DefaultChangelogNotes', () => {
       previousTag: 'v1.2.2',
       currentTag: 'v1.2.3',
       targetBranch: 'main',
+      changesBranch: 'main',
     };
     it('should build default release notes', async () => {
       const changelogNotes = new DefaultChangelogNotes();
@@ -294,6 +295,7 @@ describe('DefaultChangelogNotes', () => {
         previousTag: 'v1.2.2',
         currentTag: 'v1.2.3',
         targetBranch: 'main',
+        changesBranch: 'main',
       };
       const changelogNotes = new DefaultChangelogNotes();
       const notes = await changelogNotes.buildNotes(commits, notesOptions);

--- a/test/changelog-notes/github-changelog-notes.ts
+++ b/test/changelog-notes/github-changelog-notes.ts
@@ -67,6 +67,7 @@ describe('GitHubChangelogNotes', () => {
       previousTag: 'v1.2.2',
       currentTag: 'v1.2.3',
       targetBranch: 'main',
+      changesBranch: 'main',
     };
     let github: GitHub;
     beforeEach(async () => {
@@ -98,6 +99,7 @@ describe('GitHubChangelogNotes', () => {
         previousTag: 'v1.2.2',
         currentTag: 'v1.2.3',
         targetBranch: 'main',
+        changesBranch: 'main',
       };
       const changelogNotes = new GitHubChangelogNotes(github);
       const notes = await changelogNotes.buildNotes(commits, notesOptions);

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -123,6 +123,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -146,6 +147,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -169,6 +171,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromManifestStub,
@@ -197,6 +200,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -220,6 +224,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -243,6 +248,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -266,6 +272,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -289,6 +296,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -335,6 +343,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -383,6 +392,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -406,6 +416,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -429,6 +440,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromManifestStub,
@@ -457,6 +469,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -480,6 +493,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -503,6 +517,7 @@ describe('CLI', () => {
         token: undefined,
         apiUrl: 'https://api.github.com',
         graphqlUrl: 'https://api.github.com',
+        useGraphql: true,
       });
       sinon.assert.calledOnceWithExactly(
         fromManifestStub,
@@ -572,6 +587,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromManifestStub,
@@ -597,6 +613,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromManifestStub,
@@ -622,6 +639,7 @@ describe('CLI', () => {
             token: undefined,
             apiUrl: 'https://api.github.com',
             graphqlUrl: 'https://api.github.com',
+            useGraphql: true,
           });
           sinon.assert.calledOnceWithExactly(
             fromManifestStub,
@@ -652,6 +670,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromManifestStub,
@@ -699,6 +718,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -723,6 +743,7 @@ describe('CLI', () => {
             token: undefined,
             apiUrl: 'https://api.github.com',
             graphqlUrl: 'https://api.github.com',
+            useGraphql: true,
           });
           sinon.assert.calledOnceWithExactly(
             fromConfigStub,
@@ -751,6 +772,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -774,6 +796,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -797,6 +820,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -823,6 +847,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -850,6 +875,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -876,6 +902,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -902,6 +929,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -925,6 +953,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -951,6 +980,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -977,6 +1007,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1002,6 +1033,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1025,6 +1057,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1048,6 +1081,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1071,6 +1105,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1094,6 +1129,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1117,6 +1153,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1167,6 +1204,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromManifestStub,
@@ -1190,6 +1228,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromManifestStub,
@@ -1213,6 +1252,7 @@ describe('CLI', () => {
             token: undefined,
             apiUrl: 'https://api.github.com',
             graphqlUrl: 'https://api.github.com',
+            useGraphql: true,
           });
           sinon.assert.calledOnceWithExactly(
             fromManifestStub,
@@ -1241,6 +1281,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromManifestStub,
@@ -1264,6 +1305,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromManifestStub,
@@ -1287,6 +1329,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromManifestStub,
@@ -1341,6 +1384,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1367,6 +1411,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1390,6 +1435,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1413,6 +1459,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1436,6 +1483,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1462,6 +1510,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1485,6 +1534,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1508,6 +1558,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,
@@ -1531,6 +1582,7 @@ describe('CLI', () => {
           token: undefined,
           apiUrl: 'https://api.github.com',
           graphqlUrl: 'https://api.github.com',
+          useGraphql: true,
         });
         sinon.assert.calledOnceWithExactly(
           fromConfigStub,

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -1567,6 +1567,7 @@ describe('CLI', () => {
           headBranchName: 'release-please/bootstrap/default',
         }),
         'main',
+        'main',
         'chore: bootstrap releases for path: .',
         sinon.match.array,
         {}

--- a/test/factories/plugin-factory.ts
+++ b/test/factories/plugin-factory.ts
@@ -126,7 +126,8 @@ describe('PluginFactory', () => {
           new CustomTest(
             options.github,
             options.targetBranch,
-            options.repositoryConfig
+            options.repositoryConfig,
+            {}
           )
       );
 
@@ -147,7 +148,8 @@ describe('PluginFactory', () => {
           new CustomTest(
             options.github,
             options.targetBranch,
-            options.repositoryConfig
+            options.repositoryConfig,
+            {}
           )
       );
 

--- a/test/github.ts
+++ b/test/github.ts
@@ -970,6 +970,7 @@ describe('GitHub', () => {
             },
           ],
         },
+        'main',
         'main'
       );
       expect(pullRequest.number).to.eql(1);
@@ -1011,6 +1012,7 @@ describe('GitHub', () => {
             },
           ],
         },
+        'main',
         'main'
       );
       expect(pullRequest.number).to.eql(1);
@@ -1051,6 +1053,7 @@ describe('GitHub', () => {
             },
           ],
         },
+        'main',
         'main'
       );
       expect(pullRequest.number).to.eql(1);

--- a/test/github.ts
+++ b/test/github.ts
@@ -957,7 +957,7 @@ describe('GitHub', () => {
       });
       const pullRequest = await github.createReleasePullRequest(
         {
-          title: PullRequestTitle.ofTargetBranch('main'),
+          title: PullRequestTitle.ofTargetBranch('main', 'main'),
           body: new PullRequestBody([]),
           labels: [],
           headRefName: 'release-please--branches--main',
@@ -999,7 +999,7 @@ describe('GitHub', () => {
       });
       const pullRequest = await github.createReleasePullRequest(
         {
-          title: PullRequestTitle.ofTargetBranch('main'),
+          title: PullRequestTitle.ofTargetBranch('main', 'main'),
           body: new PullRequestBody([]),
           labels: [],
           headRefName: 'release-please--branches--main',
@@ -1040,7 +1040,7 @@ describe('GitHub', () => {
       });
       const pullRequest = await github.createReleasePullRequest(
         {
-          title: PullRequestTitle.ofTargetBranch('main'),
+          title: PullRequestTitle.ofTargetBranch('main', 'main'),
           body: new PullRequestBody([]),
           labels: [],
           headRefName: 'release-please--branches--main',
@@ -1165,7 +1165,7 @@ describe('GitHub', () => {
         },
       });
       const pullRequest = {
-        title: PullRequestTitle.ofTargetBranch('main'),
+        title: PullRequestTitle.ofTargetBranch('main', 'main'),
         body: new PullRequestBody(mockReleaseData(1000), {useComponents: true}),
         labels: [],
         headRefName: 'release-please--branches--main',

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -336,7 +336,7 @@ export function buildMockCandidatePullRequest(
   return {
     path,
     pullRequest: {
-      title: PullRequestTitle.ofTargetBranch('main'),
+      title: PullRequestTitle.ofTargetBranch('main', 'main'),
       body: new PullRequestBody([
         {
           component: options.component,
@@ -348,7 +348,7 @@ export function buildMockCandidatePullRequest(
       ]),
       updates: options.updates ?? [],
       labels: options.labels ?? [],
-      headRefName: BranchName.ofTargetBranch('main').toString(),
+      headRefName: BranchName.ofTargetBranch('main', 'main').toString(),
       version,
       draft: options.draft ?? false,
       group: options.group,

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -185,6 +185,7 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
+        github.repository.defaultBranch,
         github.repository.defaultBranch
       );
       expect(Object.keys(manifest.repositoryConfig)).lengthOf(8);
@@ -275,6 +276,7 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
+        github.repository.defaultBranch,
         github.repository.defaultBranch
       );
       expect(manifest.repositoryConfig['.'].releaseType).to.eql('java-yoshi');
@@ -304,6 +306,7 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
+        github.repository.defaultBranch,
         github.repository.defaultBranch
       );
       expect(manifest['groupPullRequestTitlePattern']).to.eql(
@@ -336,6 +339,7 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
+        github.repository.defaultBranch,
         github.repository.defaultBranch
       );
       expect(manifest.repositoryConfig['.'].tagSeparator).to.eql('-');
@@ -366,6 +370,7 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
+        github.repository.defaultBranch,
         github.repository.defaultBranch
       );
       expect(manifest.repositoryConfig['.'].extraFiles).to.eql([
@@ -410,6 +415,7 @@ describe('Manifest', () => {
         );
       const manifest = await Manifest.fromManifest(
         github,
+        github.repository.defaultBranch,
         github.repository.defaultBranch
       );
       expect(manifest.repositoryConfig['.'].includeComponentInTag).to.be.false;

--- a/test/manifest.ts
+++ b/test/manifest.ts
@@ -3483,7 +3483,7 @@ describe('Manifest', () => {
       );
       sandbox.stub(manifest, 'buildPullRequests').resolves([
         {
-          title: PullRequestTitle.ofTargetBranch('main'),
+          title: PullRequestTitle.ofTargetBranch('main', 'main'),
           body: new PullRequestBody([
             {
               notes: 'Some release notes',
@@ -3593,7 +3593,7 @@ describe('Manifest', () => {
       );
       sandbox.stub(manifest, 'buildPullRequests').resolves([
         {
-          title: PullRequestTitle.ofTargetBranch('main'),
+          title: PullRequestTitle.ofTargetBranch('main', 'main'),
           body: new PullRequestBody([
             {
               notes: 'Some release notes',
@@ -3611,7 +3611,7 @@ describe('Manifest', () => {
           draft: false,
         },
         {
-          title: PullRequestTitle.ofTargetBranch('main'),
+          title: PullRequestTitle.ofTargetBranch('main', 'main'),
           body: new PullRequestBody([
             {
               notes: 'Some release notes 2',
@@ -3676,7 +3676,7 @@ describe('Manifest', () => {
       );
       sandbox.stub(manifest, 'buildPullRequests').resolves([
         {
-          title: PullRequestTitle.ofTargetBranch('main'),
+          title: PullRequestTitle.ofTargetBranch('main', 'main'),
           body: new PullRequestBody([
             {
               notes: 'Some release notes',
@@ -3739,7 +3739,7 @@ describe('Manifest', () => {
       );
       sandbox.stub(manifest, 'buildPullRequests').resolves([
         {
-          title: PullRequestTitle.ofTargetBranch('main'),
+          title: PullRequestTitle.ofTargetBranch('main', 'main'),
           body: new PullRequestBody([
             {
               notes: 'Some release notes',
@@ -3818,7 +3818,7 @@ describe('Manifest', () => {
       );
       sandbox.stub(manifest, 'buildPullRequests').resolves([
         {
-          title: PullRequestTitle.ofTargetBranch('main'),
+          title: PullRequestTitle.ofTargetBranch('main', 'main'),
           body: new PullRequestBody([
             {
               notes: 'Some release notes',
@@ -3907,7 +3907,7 @@ describe('Manifest', () => {
         );
         sandbox.stub(manifest, 'buildPullRequests').resolves([
           {
-            title: PullRequestTitle.ofTargetBranch('main'),
+            title: PullRequestTitle.ofTargetBranch('main', 'main'),
             body,
             updates: [
               {
@@ -3989,7 +3989,7 @@ describe('Manifest', () => {
         );
         sandbox.stub(manifest, 'buildPullRequests').resolves([
           {
-            title: PullRequestTitle.ofTargetBranch('main'),
+            title: PullRequestTitle.ofTargetBranch('main', 'main'),
             body,
             updates: [
               {
@@ -4064,7 +4064,7 @@ describe('Manifest', () => {
       );
       sandbox.stub(manifest, 'buildPullRequests').resolves([
         {
-          title: PullRequestTitle.ofTargetBranch('main'),
+          title: PullRequestTitle.ofTargetBranch('main', 'main'),
           body: new PullRequestBody([
             {
               notes: 'SNAPSHOT bump',
@@ -4130,7 +4130,7 @@ describe('Manifest', () => {
       );
       sandbox.stub(manifest, 'buildPullRequests').resolves([
         {
-          title: PullRequestTitle.ofTargetBranch('main'),
+          title: PullRequestTitle.ofTargetBranch('main', 'main'),
           body: new PullRequestBody([
             {
               notes: 'Some release notes',
@@ -4210,7 +4210,7 @@ describe('Manifest', () => {
       );
       sandbox.stub(manifest, 'buildPullRequests').resolves([
         {
-          title: PullRequestTitle.ofTargetBranch('main'),
+          title: PullRequestTitle.ofTargetBranch('main', 'main'),
           body: new PullRequestBody([
             {
               notes: 'Some release notes',
@@ -4286,7 +4286,7 @@ describe('Manifest', () => {
       );
       sandbox.stub(manifest, 'buildPullRequests').resolves([
         {
-          title: PullRequestTitle.ofTargetBranch('main'),
+          title: PullRequestTitle.ofTargetBranch('main', 'main'),
           body,
           updates: [
             {

--- a/test/util/branch-name.ts
+++ b/test/util/branch-name.ts
@@ -76,6 +76,17 @@ describe('BranchName', () => {
       expect(branchName?.toString()).to.eql(name);
     });
 
+    it('parses a target branch with changes branch', () => {
+      const name = 'release-please--branches--main--changes--next';
+      const branchName = BranchName.parse(name);
+      expect(branchName).to.not.be.undefined;
+      expect(branchName?.getTargetBranch()).to.eql('main');
+      expect(branchName?.getChangesBranch()).to.eql('next');
+      expect(branchName?.getComponent()).to.be.undefined;
+      expect(branchName?.getVersion()).to.be.undefined;
+      expect(branchName?.toString()).to.eql(name);
+    });
+
     it('parses a target branch that starts with a v', () => {
       const name = 'release-please--branches--v3.3.x';
       const branchName = BranchName.parse(name);
@@ -138,15 +149,35 @@ describe('BranchName', () => {
   });
   describe('ofTargetBranch', () => {
     it('builds branchname with only target branch', () => {
-      const branchName = BranchName.ofTargetBranch('main');
+      const branchName = BranchName.ofTargetBranch('main', 'main');
       expect(branchName.toString()).to.eql('release-please--branches--main');
+    });
+    it('builds branchname with target branch and changes branch', () => {
+      const branchName = BranchName.ofTargetBranch('main', 'next');
+      expect(branchName.toString()).to.eql(
+        'release-please--branches--main--changes--next'
+      );
     });
   });
   describe('ofComponentTargetBranch', () => {
     it('builds branchname with target branch and component', () => {
-      const branchName = BranchName.ofComponentTargetBranch('foo', 'main');
+      const branchName = BranchName.ofComponentTargetBranch(
+        'foo',
+        'main',
+        'main'
+      );
       expect(branchName.toString()).to.eql(
         'release-please--branches--main--components--foo'
+      );
+    });
+    it('builds branchname with target branch, changes branch, and component', () => {
+      const branchName = BranchName.ofComponentTargetBranch(
+        'foo',
+        'main',
+        'next'
+      );
+      expect(branchName.toString()).to.eql(
+        'release-please--branches--main--changes--next--components--foo'
       );
     });
   });

--- a/test/util/pull-request-overflow-handler.ts
+++ b/test/util/pull-request-overflow-handler.ts
@@ -62,7 +62,7 @@ describe('FilePullRequestOverflowHandler', () => {
         );
       const newContents = await overflowHandler.handleOverflow(
         {
-          title: PullRequestTitle.ofTargetBranch('main'),
+          title: PullRequestTitle.ofTargetBranch('main', 'main'),
           body,
           labels: [],
           updates: [],
@@ -76,7 +76,7 @@ describe('FilePullRequestOverflowHandler', () => {
     });
     it('ignores small pull request body contents', async () => {
       const newContents = await overflowHandler.handleOverflow({
-        title: PullRequestTitle.ofTargetBranch('main'),
+        title: PullRequestTitle.ofTargetBranch('main', 'main'),
         body,
         labels: [],
         updates: [],

--- a/test/util/pull-request-title.ts
+++ b/test/util/pull-request-title.ts
@@ -60,6 +60,15 @@ describe('PullRequestTitle', () => {
       expect(pullRequestTitle?.getVersion()?.toString()).to.eql('1.2.3');
     });
 
+    it('parses a target branch and changes branch', () => {
+      const name = 'chore(next => main): release v1.2.3';
+      const pullRequestTitle = PullRequestTitle.parse(name);
+      expect(pullRequestTitle).to.not.be.undefined;
+      expect(pullRequestTitle?.getTargetBranch()).to.eql('main');
+      expect(pullRequestTitle?.getComponent()).to.be.undefined;
+      expect(pullRequestTitle?.getVersion()?.toString()).to.eql('1.2.3');
+    });
+
     it('parses a target branch and component', () => {
       const name = 'chore(main): release storage v1.2.3';
       const pullRequestTitle = PullRequestTitle.parse(name);

--- a/test/util/pull-request-title.ts
+++ b/test/util/pull-request-title.ts
@@ -104,13 +104,20 @@ describe('PullRequestTitle', () => {
   });
   describe('ofTargetBranch', () => {
     it('builds branchname with only target branch', () => {
-      const pullRequestTitle = PullRequestTitle.ofTargetBranch('main');
+      const pullRequestTitle = PullRequestTitle.ofTargetBranch('main', 'main');
       expect(pullRequestTitle.toString()).to.eql('chore(main): release');
+    });
+    it('builds branchname with target branch and changes branch', () => {
+      const pullRequestTitle = PullRequestTitle.ofTargetBranch('main', 'next');
+      expect(pullRequestTitle.toString()).to.eql(
+        'chore(next => main): release'
+      );
     });
   });
   describe('ofTargetBranchVersion', () => {
     it('builds branchname with target branch and version', () => {
       const pullRequestTitle = PullRequestTitle.ofTargetBranchVersion(
+        'main',
         'main',
         Version.parse('1.2.3')
       );
@@ -121,6 +128,7 @@ describe('PullRequestTitle', () => {
     it('builds branchname with target branch and component', () => {
       const pullRequestTitle = PullRequestTitle.ofComponentTargetBranchVersion(
         'foo',
+        'main',
         'main',
         Version.parse('1.2.3')
       );
@@ -270,6 +278,7 @@ describe('PullRequestTitle with custom pullRequestTitlePattern', () => {
     it('builds branchname with only target branch', () => {
       const pullRequestTitle = PullRequestTitle.ofTargetBranchVersion(
         'main',
+        'next',
         Version.parse('1.2.3'),
         'chore${scope}: 🔖 release${component} ${version}'
       );
@@ -283,6 +292,7 @@ describe('PullRequestTitle with custom pullRequestTitlePattern', () => {
       const pullRequestTitle = PullRequestTitle.ofComponentTargetBranchVersion(
         'foo',
         'main',
+        'next',
         Version.parse('1.2.3'),
         'chore${scope}: 🔖 release${component} ${version}'
       );


### PR DESCRIPTION
This pull request adds a CLI flag `--changes-branch` that makes it possible to override the branch used to find changes related to the release.

Usage example:

```
$ npm run cli -- release-pr --token=$TOKEN --repo-url=dgellow/test-release-please-behaviour --target-branch=main --changes-branch=next --debug
```

Results in https://github.com/dgellow/test-release-please-behaviour/pull/16.